### PR TITLE
Adds a default value for 'condition_field' and "condition_values"

### DIFF
--- a/application_cluster/variables.tf
+++ b/application_cluster/variables.tf
@@ -77,11 +77,13 @@ variable "loadbalancer_listener_ssl_arn" {
 variable "application_cluster_listener_rule_condition_field" {
   description = "field on which the condition should be triggered"
   type = "string"
+  default = ""
 }
 
 variable "application_cluster_listener_rule_condition_values" {
   description = "values which should be used on condition"
   type = "list"
+  default = []
 }
 
 variable application_cluster_target_group_protocol {


### PR DESCRIPTION
Because otherwise it is impossible to skip the listener_arns